### PR TITLE
make the BPF program to cause EPERM

### DIFF
--- a/tracer.cc
+++ b/tracer.cc
@@ -43,7 +43,7 @@ int handle_incr(struct pt_regs *ctx)
   bpf_usdt_readarg(1, ctx, &ev.value);
 
   ev.value++;
-  hash.insert(&ev.tid, &ev.value);
+  hash.insert(&task->pid, &ev.value);
 
   events.perf_submit(ctx, &ev, sizeof(ev));
   return 0;


### PR DESCRIPTION
The change causes BPF compilation failure with `EPERM`, showing:


```
$ make && ./run.pl
clang++ -Wall -Wextra -g3 -fsanitize=address -lbcc -o tracer tracer.cc
main: pid=220210
/virtual/main.c:33:15: warning: passing 'const pid_t *' (aka 'const int *') to parameter of type 'pid_t *' (aka 'int *')
      discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  hash.insert(&task->pid, &ev.value);
              ^~~~~~~~~~
1 warning generated.
tracer: initialized
bpf: Failed to load program: Permission denied
0: (bf) r6 = r1
1: (85) call bpf_get_current_task#35
2: (bf) r7 = r0
3: (b7) r8 = 0
4: (63) *(u32 *)(r10 -24) = r8
last_idx 4 first_idx 0
regs=100 stack=0 before 3: (b7) r8 = 0
5: (bf) r3 = r7
6: (07) r3 += 2244
7: (bf) r1 = r10
8: (07) r1 += -24
9: (b7) r2 = 4
10: (85) call bpf_probe_read#4
last_idx 10 first_idx 0
regs=4 stack=0 before 9: (b7) r2 = 4
11: (61) r1 = *(u32 *)(r10 -24)
12: (63) *(u32 *)(r10 -16) = r1
13: (07) r7 += 2240
14: (63) *(u32 *)(r10 -8) = r8
15: (bf) r1 = r10
16: (07) r1 += -8
17: (b7) r2 = 4
18: (bf) r3 = r7
19: (85) call bpf_probe_read#4
last_idx 19 first_idx 11
regs=4 stack=0 before 18: (bf) r3 = r7
regs=4 stack=0 before 17: (b7) r2 = 4
20: (61) r1 = *(u32 *)(r10 -8)
21: (63) *(u32 *)(r10 -12) = r1
22: (79) r3 = *(u64 *)(r6 +152)
23: (7b) *(u64 *)(r10 -8) = r8
24: (07) r3 += 152
25: (bf) r1 = r10
26: (07) r1 += -8
27: (b7) r2 = 8
28: (85) call bpf_probe_read#4
last_idx 28 first_idx 11
regs=4 stack=0 before 27: (b7) r2 = 8
29: (79) r1 = *(u64 *)(r10 -8)
30: (07) r1 += 1
31: (7b) *(u64 *)(r10 -24) = r1
32: (18) r1 = 0xffff8fa407f42400
34: (bf) r8 = r10
35: (07) r8 += -24
36: (bf) r2 = r7
37: (bf) r3 = r8
38: (b7) r4 = 1
39: (85) call bpf_map_update_elem#2
R2 type=inv expected=fp
processed 39 insns (limit 1000000) max_states_per_insn 0 total_states 2 peak_states 2 mark_read 1

tracer: error: attach_usdt_all: USDT hello:incr from binary  PID 220210 for probe handle_incr at /proc/220210/root/home/goro/ghq/github.com/gfx/hello_bpf/main address 4994147: Failed to load handle_incr: -1
```

## Environment

```
$ uname -a
Linux ubuntu20 5.4.0-65-generic #73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.1 LTS
Release:	20.04
Codename:	focal
```

In VMWare. Not in a container.